### PR TITLE
Cleanup of the nunit branch + fixing test view in appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vs/
 bin/
 obj/
+*.DotSettings.user
 
 .idea
 .DS_Store

--- a/Snapper.Core.Tests/Snapper.Core.Tests.csproj
+++ b/Snapper.Core.Tests/Snapper.Core.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.5</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
-    <LangVersion >latest</LangVersion >
+    <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snapper.Core/Snapper.Core.csproj
+++ b/Snapper.Core/Snapper.Core.csproj
@@ -9,7 +9,6 @@
 See Project Site for more details</Description>
     <PackageLicenseUrl>https://github.com/theramis/Snapper/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>testing, test, snapshot, jest</PackageTags>
-    <LangVersion >latest</LangVersion >
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/Snapper.Json.Nunit.Tests/Snapper.Json.Nunit.Tests.csproj
+++ b/Snapper.Json.Nunit.Tests/Snapper.Json.Nunit.Tests.csproj
@@ -1,19 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" >
-  <PropertyGroup >
-    <TargetFramework >netcoreapp2.0</TargetFramework >
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
-    <RootNamespace >Snapper.Json.NUnit.Tests</RootNamespace >
-  </PropertyGroup >
-  <ItemGroup >
+    <RootNamespace>Snapper.Json.NUnit.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-  </ItemGroup >
-  <ItemGroup >
+  </ItemGroup>
+  <ItemGroup>
     <Folder Include="_snapshots" />
-  </ItemGroup >
-  <ItemGroup >
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Snapper.Json.Nunit\Snapper.Json.Nunit.csproj" />
-  </ItemGroup >
-</Project >
+  </ItemGroup>
+</Project>

--- a/Snapper.Json.Nunit.Tests/Snapper.Json.Nunit.Tests.csproj
+++ b/Snapper.Json.Nunit.Tests/Snapper.Json.Nunit.Tests.csproj
@@ -1,24 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" >
-
   <PropertyGroup >
     <TargetFramework >netcoreapp2.0</TargetFramework >
-
-    <IsPackable >false</IsPackable >
-
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <LangVersion>latest</LangVersion>
     <RootNamespace >Snapper.Json.NUnit.Tests</RootNamespace >
   </PropertyGroup >
-
   <ItemGroup >
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup >
-
   <ItemGroup >
     <Folder Include="_snapshots" />
   </ItemGroup >
-
   <ItemGroup >
     <ProjectReference Include="..\Snapper.Json.Nunit\Snapper.Json.Nunit.csproj" />
   </ItemGroup >
-
 </Project >

--- a/Snapper.Json.Nunit/Snapper.Json.Nunit.csproj
+++ b/Snapper.Json.Nunit/Snapper.Json.Nunit.csproj
@@ -9,8 +9,8 @@
 See Project Site for more details</Description>
     <PackageProjectUrl>https://github.com/theramis/Snapper</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/theramis/Snapper/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageTags>testing, test, snapshot, jest, json, xunit</PackageTags>
-    <LangVersion>7.2</LangVersion>
+    <PackageTags>testing, test, snapshot, jest, json, nunit</PackageTags>
+    <LangVersion>latest</LangVersion>
     <RootNamespace >Snapper.Json.Nunit</RootNamespace >
   </PropertyGroup>
   <ItemGroup>

--- a/Snapper.Json.Nunit/Snapper.Json.Nunit.csproj
+++ b/Snapper.Json.Nunit/Snapper.Json.Nunit.csproj
@@ -11,7 +11,7 @@ See Project Site for more details</Description>
     <PackageLicenseUrl>https://github.com/theramis/Snapper/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>testing, test, snapshot, jest, json, nunit</PackageTags>
     <LangVersion>latest</LangVersion>
-    <RootNamespace >Snapper.Json.Nunit</RootNamespace >
+    <RootNamespace>Snapper.Json.Nunit</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Snapper.Core\Snapper.Core.csproj" />

--- a/Snapper.Json.Tests/Snapper.Json.Tests.csproj
+++ b/Snapper.Json.Tests/Snapper.Json.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.5</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
-    <LangVersion >latest</LangVersion >
+    <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snapper.Json.Xunit/Snapper.Json.Xunit.csproj
+++ b/Snapper.Json.Xunit/Snapper.Json.Xunit.csproj
@@ -10,7 +10,6 @@ See Project Site for more details</Description>
     <PackageProjectUrl>https://github.com/theramis/Snapper</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/theramis/Snapper/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>testing, test, snapshot, jest, json, xunit</PackageTags>
-    <LangVersion >latest</LangVersion >
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Snapper.Json/Properties/AssemblyInfo.cs
+++ b/Snapper.Json/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Snapper.Json.Nunit")]
-[assembly: InternalsVisibleTo("Snapper.Json.XUnit")]
+[assembly: InternalsVisibleTo("Snapper.Json.Xunit")]

--- a/Snapper.Json/Snapper.Json.csproj
+++ b/Snapper.Json/Snapper.Json.csproj
@@ -9,7 +9,6 @@ See Project Site for more details</Description>
     <PackageProjectUrl>https://github.com/theramis/Snapper</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/theramis/Snapper/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>testing, test, snapshot, jest, json</PackageTags>
-    <LangVersion >latest</LangVersion >
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,8 @@ build:
   project: Snapper.sln
   publish_nuget: true
 
+skip_branch_with_pr: true
+
 test: off
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build:
 test: off
 
 test_script:
-  - ps: dotnet vstest (Get-ChildItem -Path "*/bin/*Tests.dll" -Recurse)
+  - ps: dotnet test
 
 deploy:
   - provider: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build:
 test: off
 
 test_script:
-  - ps: dotnet test
+  - ps: dotnet test --no-build
 
 deploy:
   - provider: NuGet


### PR DESCRIPTION
**Changes**
- Turns out there were duplicate `<LangVersion >latest</LangVersion>` in the csproj files so removed those
- Added `<IsTestProject>true</IsTestProject>` to all test projects so we can use `dotnet test` command for all projects
- Use `dotnet test` in appveyor in the hope that it shows the nunit tests in the tests tab