### PR TITLE
[Issue #27] Catch not implemented exception when determining test method

### DIFF
--- a/project/Snapper/Core/TestMethodResolver/TestMethods/BaseTestMethod.cs
+++ b/project/Snapper/Core/TestMethodResolver/TestMethods/BaseTestMethod.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -15,13 +16,23 @@ namespace Snapper.Core.TestMethodResolver.TestMethods
 
         public bool IsTestMethod()
         {
-            var attribute = BaseMethod?.CustomAttributes.FirstOrDefault(a =>
+            try
             {
-                var attributeName = a.AttributeType.FullName;
-                return attributeName == AttributeName;
-            });
+                var attribute = BaseMethod?.CustomAttributes.FirstOrDefault(a =>
+                {
+                    var attributeName = a.AttributeType.FullName;
+                    return attributeName == AttributeName;
+                });
 
-            return attribute != null;
+                return attribute != null;
+            }
+            catch (NotImplementedException)
+            {
+                // MemberInfo.CustomAttributes in some cases can throw a NotImplementedException.
+                // In this case we assume that the method is not a test method.
+                // See issue: https://github.com/theramis/Snapper/issues/27
+                return false;
+            }
         }
 
         public string MethodName => BaseMethod.Name;


### PR DESCRIPTION
## Problem
See issue #27 

## Solution
Catching the not implemented exception and assuming that the method is not a test method. Ideally it would be nice to figure out which methods can throw a `NotImplementedException` but my search hasn't lead me anywhere. 