### PR TITLE
Create new test project for test framework support tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ test: off
 test_script:
   - ps: dotnet test --no-build
   - ps: dotnet test Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj --logger:Appveyor --no-build
+  - ps: dotnet test Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj --logger:Appveyor --no-build
 
 deploy:
   - provider: NuGet

--- a/project/Snapper.sln
+++ b/project/Snapper.sln
@@ -21,6 +21,8 @@ ProjectSection(SolutionItems) = preProject
 	Directory.Build.props = Directory.Build.props
 EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Snapper.TestFrameworkSupport.Tests", "Tests\Snapper.TestFrameworkSupport.Tests\Snapper.TestFrameworkSupport.Tests.csproj", "{21D3BF77-636D-4953-AA6A-C68FC39D3A1F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{B92D380C-B704-4BB8-A9AF-AE2B907ABB92}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B92D380C-B704-4BB8-A9AF-AE2B907ABB92}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B92D380C-B704-4BB8-A9AF-AE2B907ABB92}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21D3BF77-636D-4953-AA6A-C68FC39D3A1F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21D3BF77-636D-4953-AA6A-C68FC39D3A1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21D3BF77-636D-4953-AA6A-C68FC39D3A1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21D3BF77-636D-4953-AA6A-C68FC39D3A1F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,6 +61,7 @@ Global
 		{6869334B-0C1C-4CA2-8823-C09DE1EF4540} = {634162BB-9132-43E2-8741-DEE5F2F202A1}
 		{1E140E12-9738-402A-984C-B59AD0382E6E} = {634162BB-9132-43E2-8741-DEE5F2F202A1}
 		{B92D380C-B704-4BB8-A9AF-AE2B907ABB92} = {634162BB-9132-43E2-8741-DEE5F2F202A1}
+		{21D3BF77-636D-4953-AA6A-C68FC39D3A1F} = {634162BB-9132-43E2-8741-DEE5F2F202A1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {24DD48CC-B026-4BFC-BED2-9554A34FB24C}

--- a/project/Tests/Snapper.Internals.Tests/Core/TestMethodResolverTests.cs
+++ b/project/Tests/Snapper.Internals.Tests/Core/TestMethodResolverTests.cs
@@ -16,7 +16,7 @@ namespace Snapper.Internals.Tests.Core
         }
 
         [Fact]
-        public void XUnitFactTestMethod()
+        public void ResolvedTestMethod_HasCorrectData()
         {
             var testMethod = _testMethodResolver.ResolveTestMethod();
 
@@ -24,29 +24,11 @@ namespace Snapper.Internals.Tests.Core
                 $"{nameof(TestMethodResolverTests)}.cs");
 
             testMethod.FileName.Should().EndWith(fileName);
-            testMethod.MethodName.Should().Be(nameof(XUnitFactTestMethod));
+            testMethod.MethodName.Should().Be(nameof(ResolvedTestMethod_HasCorrectData));
 
             testMethod.BaseMethod.ReflectedType?.FullName.Should()
                 .Be($"Snapper.Internals.Tests.Core.{nameof(TestMethodResolverTests)}");
-            testMethod.BaseMethod.Name.Should().Be(nameof(XUnitFactTestMethod));
-        }
-
-        [Theory]
-        [InlineData("Data")]
-        [SuppressMessage("ReSharper", "xUnit1026")]
-        public void XUnitTheoryTestMethod(string value)
-        {
-            var testMethod = _testMethodResolver.ResolveTestMethod();
-
-            var fileName = Path.Combine("Snapper.Internals.Tests", "Core",
-                $"{nameof(TestMethodResolverTests)}.cs");
-
-            testMethod.FileName.Should().EndWith(fileName);
-            testMethod.MethodName.Should().Be(nameof(XUnitTheoryTestMethod));
-
-            testMethod.BaseMethod.ReflectedType?.FullName.Should()
-                .Be($"Snapper.Internals.Tests.Core.{nameof(TestMethodResolverTests)}");
-            testMethod.BaseMethod.Name.Should().Be(nameof(XUnitTheoryTestMethod));
+            testMethod.BaseMethod.Name.Should().Be(nameof(ResolvedTestMethod_HasCorrectData));
         }
     }
 }

--- a/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
+++ b/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2;net45</TargetFrameworks>
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
 

--- a/project/Tests/Snapper.TestFrameworkSupport.Tests/NUnitFrameworkSupportTests.cs
+++ b/project/Tests/Snapper.TestFrameworkSupport.Tests/NUnitFrameworkSupportTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.CompilerServices;
+using NUnit.Framework;
+
+namespace Snapper.TestFrameworkSupport.Tests
+{
+    public class NUnitFrameworkSupportTests
+    {
+        [Test]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void NUnitTestTestMethod()
+        { 
+            "value".ShouldMatchInlineSnapshot("value");
+        }
+        
+        [Datapoint]
+        public string value = string.Empty;
+        
+        [Theory]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void NUnitTheoryTestMethod(string value)
+        { 
+            value.ShouldMatchInlineSnapshot(value);
+        }
+    }
+}

--- a/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
+++ b/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
@@ -6,11 +6,13 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/project/Tests/Snapper.TestFrameworkSupport.Tests/XUnitFrameworkSupportTests.cs
+++ b/project/Tests/Snapper.TestFrameworkSupport.Tests/XUnitFrameworkSupportTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Snapper.TestFrameworkSupport.Tests
+{
+    public class XUnitFrameworkSupportTests
+    {
+        [Fact]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void XUnitFactTestMethod()
+        { 
+            "value".ShouldMatchInlineSnapshot("value");
+        }
+        
+        [Theory]
+        [InlineData("Data")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void XUnitTheoryTestMethod(string value)
+        { 
+            value.ShouldMatchInlineSnapshot(value);
+        }
+    }
+}


### PR DESCRIPTION
Created a new test project for test framework support tests

Its a bit ugly since there are two test frameworks in this new project and it would only expand to more and more. Hence why I made it into its own test project so the uglyness is contained. 

