### PR TITLE
Clean up nuget packages and update to latest

### DIFF
--- a/project/Snapper.Nunit/Snapper.Nunit.csproj
+++ b/project/Snapper.Nunit/Snapper.Nunit.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
@@ -21,11 +21,11 @@ See Project Site for more details</Description>
 
     <ItemGroup>
       <ProjectReference Include="..\Snapper\Snapper.csproj" />
-      <PackageReference Include="MinVer" Version="1.1.0" >
+      <PackageReference Include="MinVer" Version="2.0.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
       <PackageReference Include="NUnit" Version="3.6.0" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All"/>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/project/Snapper/Core/AlwaysFalseSnapshotUpdateDecider.cs
+++ b/project/Snapper/Core/AlwaysFalseSnapshotUpdateDecider.cs
@@ -1,6 +1,6 @@
 namespace Snapper.Core
 {
-    public class AlwaysFalseSnapshotUpdateDecider : ISnapshotUpdateDecider
+    internal class AlwaysFalseSnapshotUpdateDecider : ISnapshotUpdateDecider
     {
         public bool ShouldUpdateSnapshot() => false;
     }

--- a/project/Snapper/Snapper.csproj
+++ b/project/Snapper/Snapper.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
@@ -20,11 +20,11 @@ See Project Site for more details</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="1.1.0" >
+    <PackageReference Include="MinVer" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/project/Tests/Snapper.Internals.Tests/Snapper.Internals.Tests.csproj
+++ b/project/Tests/Snapper.Internals.Tests/Snapper.Internals.Tests.csproj
@@ -6,11 +6,11 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
+++ b/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>

--- a/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
+++ b/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
@@ -7,9 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/project/Tests/Snapper.Tests/Snapper.Tests.csproj
+++ b/project/Tests/Snapper.Tests/Snapper.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2;net45</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -6,11 +6,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Changes
- Clean up some redundant nuget packages
- Update nuget packages to the latest
- Change a public class to be internal as it was not meant to be exposed. 