### PR TITLE
Use JsonConvert.DeserializeObject instead JObject.Parse 

### DIFF
--- a/project/Snapper/Json/JsonSnapshotSanitiser.cs
+++ b/project/Snapper/Json/JsonSnapshotSanitiser.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Snapper.Exceptions;
 
@@ -16,7 +17,7 @@ namespace Snapper.Json
                     {
                         try
                         {
-                            return JObject.Parse(stringSnapshot);
+                            return JsonConvert.DeserializeObject(stringSnapshot, SnapperSettings.SnapshotDeserializationSettings());
                         }
                         catch (Exception e)
                         {

--- a/project/Snapper/SnapperSettings.cs
+++ b/project/Snapper/SnapperSettings.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Snapper
+{
+    public static class SnapperSettings
+    {
+        public static Func<JsonSerializerSettings> SnapshotDeserializationSettings { get; set; } = () => null;
+    }
+}

--- a/project/Tests/Snapper.Internals.Tests/Json/JsonSnapshotSanitiserTests.cs
+++ b/project/Tests/Snapper.Internals.Tests/Json/JsonSnapshotSanitiserTests.cs
@@ -101,7 +101,6 @@ namespace Snapper.Internals.Tests.Json
                 .Be($"{{{Environment.NewLine}" +
                     "  \"Key\": \"2010-12-31T00:00:00+00:00\"" +
                     $"{Environment.NewLine}}}");
-
         }
     }
 }

--- a/project/Tests/Snapper.Internals.Tests/Json/JsonSnapshotSanitiserTests.cs
+++ b/project/Tests/Snapper.Internals.Tests/Json/JsonSnapshotSanitiserTests.cs
@@ -1,4 +1,6 @@
+﻿using System;
 using FluentAssertions;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Snapper.Exceptions;
 using Snapper.Json;
@@ -80,6 +82,26 @@ namespace Snapper.Internals.Tests.Json
             exception.GetType().FullName.Should().Be(typeof(MalformedJsonSnapshotException).FullName);
             exception.Message.Should()
                 .Be("The snapshot provided contains malformed JSON. See inner exception for details.");
+        }
+
+        [Fact]
+        public void DateTimeOffsetStringTestWithSerializationSettings()
+        {
+            SnapperSettings.SnapshotDeserializationSettings = () => new JsonSerializerSettings()
+            {
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                DateParseHandling = DateParseHandling.DateTimeOffset,
+            };
+
+            var sanitisedObject = _sanitiser.SanitiseSnapshot("{" +
+                                        "\"Key\" : \"2010-12-31T00:00:00+00:00\"" +
+                                        "}").ToString();
+
+            sanitisedObject.Should()
+                .Be($"{{{Environment.NewLine}" +
+                    "  \"Key\": \"2010-12-31T00:00:00+00:00\"" +
+                    $"{Environment.NewLine}}}");
+
         }
     }
 }


### PR DESCRIPTION
At work I'm using snapper quite extensively for api contract testing and found a little bit of a problem when trying to assert against a snapshot that contains `DateTimeOffset` properties.

After a little bit of digging it looks like it's related to `Newtonsoft.Json` issue reported here https://github.com/JamesNK/Newtonsoft.Json/issues/1110

Thought it would be nice to have it a bit more flexible so that deserialisation configuration can be changed if needed.

What do you think about this proposal?