### PR TITLE
[Issue #50] Update Json parsing to ignore metadata properties

### DIFF
--- a/project/Snapper/Json/JObjectHelper.cs
+++ b/project/Snapper/Json/JObjectHelper.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -8,7 +8,8 @@ namespace Snapper.Json
     {
         private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
         {
-            DateParseHandling = DateParseHandling.None
+            DateParseHandling = DateParseHandling.None,
+            MetadataPropertyHandling = MetadataPropertyHandling.Ignore
         };
 
         public static JObject ParseFromString(string jsonString)

--- a/project/Tests/Snapper.Tests/SnapperNewtonsoftNuisancesTests.cs
+++ b/project/Tests/Snapper.Tests/SnapperNewtonsoftNuisancesTests.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
+using Newtonsoft.Json.Linq;
 using Snapper.Attributes;
 using Xunit;
 
@@ -63,6 +64,68 @@ namespace Snapper.Tests
             snapshot.ShouldMatchInlineSnapshot("{" +
                                                "\"Key\" : \"2010-12-31T00:00:00Z\"" +
                                                "}");
+        }
+
+        [Theory]
+        [InlineData("id")]
+        [InlineData("type")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void MetadataPropertiesAreReadAsStringsBySnapper_UsingStringSnapshot_FileSnapshot(string metadataProp)
+        {
+            var snapshot = $@"{{
+                ""${metadataProp}"": ""metadata"",
+                ""key"": ""value""
+            }}";
+
+            snapshot.ShouldMatchChildSnapshot(metadataProp);
+        }
+
+        [Theory]
+        [InlineData("id")]
+        [InlineData("type")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void MetadataPropertiesAreReadAsStringsBySnapper_UsingObjectSnapshot_FileSnapshot(string metadataProp)
+        {
+            var snapshot = JObject.Parse($@"{{
+                ""${metadataProp}"": ""metadata"",
+                ""key"": ""value""
+            }}");
+
+            snapshot.ShouldMatchChildSnapshot(metadataProp);
+        }
+
+        [Theory]
+        [InlineData("id")]
+        [InlineData("type")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void MetadataPropertiesAreReadAsStringsBySnapper_UsingStringSnapshot_InlineSnapshot(string metadataProp)
+        {
+            var snapshot = $@"{{
+                ""${metadataProp}"": ""metadata"",
+                ""key"": ""value""
+            }}";
+
+            snapshot.ShouldMatchInlineSnapshot($@"{{
+                ""${metadataProp}"": ""metadata"",
+                ""key"": ""value""
+            }}");
+        }
+
+        [Theory]
+        [InlineData("id")]
+        [InlineData("type")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void MetadataPropertiesAreReadAsStringsBySnapper_UsingObjectSnapshot_InlineSnapshot(string metadataProp)
+        {
+            var snapshot = JObject.Parse($@"{{
+                ""${metadataProp}"": ""metadata"",
+                ""key"": ""value""
+            }}");
+
+            snapshot.ShouldMatchInlineSnapshot($@"{{
+                ""${metadataProp}"": ""metadata"",
+                ""key"": ""value""
+            }}");
         }
     }
 }

--- a/project/Tests/Snapper.Tests/_snapshots/SnapperNewtonsoftNuisancesTests.json
+++ b/project/Tests/Snapper.Tests/_snapshots/SnapperNewtonsoftNuisancesTests.json
@@ -4,5 +4,25 @@
   },
   "DateTimeIsParsedAsStringBySnapper_UsingObjectSnapshot_FileSnapshot": {
     "Key": "2010-12-31T00:00:00Z"
+  },
+  "MetadataPropertiesAreReadAsStringsBySnapper_UsingStringSnapshot_FileSnapshot": {
+    "id": {
+      "$id": "metadata",
+      "key": "value"
+    },
+    "type": {
+      "$type": "metadata",
+      "key": "value"
+    }
+  },
+  "MetadataPropertiesAreReadAsStringsBySnapper_UsingObjectSnapshot_FileSnapshot": {
+    "type": {
+      "$type": "metadata",
+      "key": "value"
+    },
+    "id": {
+      "$id": "metadata",
+      "key": "value"
+    }
   }
 }


### PR DESCRIPTION
## Changes
Fixes issue #50.
Newtonsoft parse properties like `$id` and `$type` as metadata properties by default and excludes them when taking a JObject and converting it to string. 
Updating the deserialising settings to treat the metadata properties as strings.

I believe this bug was introduced as part of v2.2.1

@ViceIce 