### PR TITLE
[Issue #53] Use JObjectHelper when storing snapshots

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ test_script:
 deploy:
   - provider: NuGet
     api_key:
-      secure: whd5/YXtYa+CNPeFC5ks3ZbJquJTVAxGQK1Zwnid9qOl/LmGmsGI7JuFWKK3rp9g
+      secure: PdJ/CluggDP2N3kPqkGB0LNmIM31WtQCAw5pKea//VVtOcmExIWTUzIL4/Wo9P0r
     skip_symbols: false
     artifact: /.*\.s?nupkg/
     on:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ nav_order: 99
 # Changelog
 All notable changes to the Snapper project.
 
+## [2.2.3] - 2020-02-15
+### Bug Fix
+- [Issue #53](https://github.com/theramis/Snapper/issues/53) [PR #55](https://github.com/theramis/Snapper/pull/55) Use JObjectHelper when storing snapshots. Thanks to [@ViceIce](https://github.com/ViceIce) for surfacing the issue.
+
 ## [2.2.2] - 2020-02-01
 ### Bug Fix
 - [Issue #50](https://github.com/theramis/Snapper/issues/50) [PR #51](https://github.com/theramis/Snapper/pull/51) Fixed parsing of metadata properties so that they are treated as string by NewtonSoft. Thanks to [@ViceIce](https://github.com/ViceIce) for surfacing the issue.
@@ -124,6 +128,7 @@ The first stable release!
 - **Snapper.Json**: Extends Snapper.Core to provide storing snapshots in Json format
 - **Snapper.Json.Xunit**: Extends Snapper.Json and integrates with the XUnit testing framework.
 
+[2.2.3]: https://github.com/theramis/Snapper/compare/2.2.2...2.2.3
 [2.2.2]: https://github.com/theramis/Snapper/compare/2.2.1...2.2.2
 [2.2.1]: https://github.com/theramis/Snapper/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/theramis/Snapper/compare/2.1.0...2.2.0

--- a/project/Snapper/Json/JsonSnapshotStore.cs
+++ b/project/Snapper/Json/JsonSnapshotStore.cs
@@ -36,7 +36,7 @@ namespace Snapper.Json
         {
             Directory.CreateDirectory(Path.GetDirectoryName(snapshotId.FilePath));
 
-            var newSnapshot = JObject.FromObject(value);
+            var newSnapshot = JObjectHelper.FromObject(value);
 
             JToken newSnapshotToWrite;
 


### PR DESCRIPTION
Fixes the bug reported here https://github.com/theramis/Snapper/issues/53

This was missed when `JObjectHelper` was added in this PR https://github.com/theramis/Snapper/pull/45

@ViceIce 