### PR TITLE
Add an environment variable defined in Azure DevOps piplines and rele…

### DIFF
--- a/project/Snapper/Core/SnapshotUpdateDecider.cs
+++ b/project/Snapper/Core/SnapshotUpdateDecider.cs
@@ -21,6 +21,7 @@ namespace Snapper.Core
             "CI", // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
             "CONTINUOUS_INTEGRATION", // Travis CI, Cirrus CI
             "BUILD_NUMBER", // Jenkins, TeamCity
+            "BUILD_BUILDNUMBER", // Azure DevOps
             "RUN_ID" // TaskCluster, dsari
         };
 


### PR DESCRIPTION
Azure DevOps recently made a change that made pipelines unable to detect the CI environment. Adding a variable defined per https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables