### PR TITLE
[Issue #30] Introduce new experimental method for finer control of snapshot files

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,6 +8,7 @@
     - [Basics](pages/snapper/basics.md)
     - [Updating Snapshots](pages/snapper/updating_snapshots.md)
     - [Storing Snapshots per class](pages/snapper/snapshots_per_class.md)
+    - [Advanced Snapshot file control](pages/snapper/advanced_snapshot_control.md)
 
 - [Snapper.Nunit](pages/snapper_nunit.md)
 - [Test Frameworks](pages/supported_test_frameworks.md)

--- a/docs/pages/faqs.md
+++ b/docs/pages/faqs.md
@@ -3,7 +3,7 @@
 ### Why am I getting a `SupportedTestMethodNotFoundException`?
 ```
 Snapper.Exceptions.SupportedTestMethodNotFoundException : A supported test method was not found.
-Make sure you are using Snapper inside a supported test framework. See https://theramis.github.io/Snapper/faqs.html for more info.
+Make sure you are using Snapper inside a supported test framework. See https://theramis.github.io/Snapper/#/pages/faqs for more info.
 ```
 If you got an exception when running tests with Snapper similiar to the one above there are two reasons why this could be happening.
 
@@ -22,3 +22,6 @@ There are currently two solution for this issue.
 ```
 
 For more information see this issue: [theramis/snapper#16](https://github.com/theramis/Snapper/issues/16)
+
+If none of the solutions above work its possible you have encountered a usecase where Snapper is unable to determine the test. There has been one use reported use case like this before. See https://github.com/theramis/Snapper/issues/30. 
+In this case the recommended solution is to use [Advanced Snapshot file control](/pages/snapper/advanced_snapshot_control?id=advanced-snapshot-file-control) to create snapshots.

--- a/docs/pages/snapper/advanced_snapshot_control.md
+++ b/docs/pages/snapper/advanced_snapshot_control.md
@@ -1,0 +1,99 @@
+# Advanced Snapshot File Control
+
+> This is currently an experimental feature available from v2.2.4 onwards
+
+Sometimes you want to have more control over how the snapshot file looks and where it should be created. 
+
+You can pass in an instance of the [SnapshotId](https://github.com/theramis/Snapper/blob/master/project/Snapper/Core/SnapshotId.cs) class to the `ShouldMatchSnapshot()` method as seen in the example below.
+
+```csharp
+public class MyTests
+{
+    public void MyFirstTest()
+    {
+        // Arrange
+        var snapshot = new
+        {
+            TestValue = "value"
+        };
+
+        // Act/Assert
+        snapshot.ShouldMatchSnapshot(new SnapshotId(
+            "C:\\MyTestProject\\mysnapshotsfolder",     // Directory where the snapshot file is stored
+            nameof(MyTests),                            // Class Name
+            nameof(MyFirstTest),                        // Method Name
+            "childSnapshotName",                        // Child Snapshot Name
+            storeSnapshotsPerClass: false));            // Store Snapshots per class
+    }
+}
+```
+
+This will create the following snapshot file `C:\MyTestProject\mysnapshotsfolder\MyTests.json` with this content. 
+
+```json
+{
+    "MyFirstTest": {
+        "childSnapshotName": {
+            "TestValue": "value"
+        }
+    }
+}
+```
+
+## How does Snapper use SnapshotId to create the snapshot
+
+`SnapshotId` has five different parameters it takes in and they are used to determine the details of the snapshot file. 
+
+The directory where the snapshot file is stored is one of the parameters passed in. 
+
+The name of the snapshot file changes depending on the `storeSnapshotsPerClass` parameter. If it is `true` then the name of the snapshot file is the value of the `className` parameter. If it is `false` then the name of the snapshot file is a combination of the `className` and `methodName` parameters.
+
+The `childSnapshotName` parameter is used to decide if the snapshot has a child snapshot or not. See [Child Snapshots](/pages/snapper/basics?id=child-snapshots) for more details.
+
+The `storeSnapshotsPerClass` parameter is essentially the same as the `[StoreSnapshotsPerClass]` attribute. See [Snapshots per class](/pages/snapper/snapshots_per_class?id=snapshots-per-class) for more info.
+
+See [SnapshotId](https://github.com/theramis/Snapper/blob/master/project/Snapper/Core/SnapshotId.cs) for the actual implementation which should be easy to understand.
+
+### Examples
+
+```csharp
+// Creates `C:\snaps\class_method.json`
+snapshot.ShouldMatchSnapshot(new SnapshotId("C:\\snaps", "class", "method", "child", false);
+/*
+{
+    "child": {
+        ...
+    }
+}
+*/
+
+// Creates `C:\snaps\class_method.json`
+snapshot.ShouldMatchSnapshot(new SnapshotId("C:\\snaps", "class", "method", null, false);
+/*
+{
+    ...
+}
+*/
+
+// Creates `C:\snaps\class.json`
+snapshot.ShouldMatchSnapshot(new SnapshotId("C:\\snaps", "class", "method", null, true);
+/*
+{
+    "method": {
+        ...
+    }
+}
+*/
+
+// Creates `C:\snaps\class.json`
+snapshot.ShouldMatchSnapshot(new SnapshotId("C:\\snaps", "class", "method", "child", true);
+/*
+{
+    "method": {
+        "child": {
+            ...
+        }
+    }
+}
+*/
+```

--- a/docs/pages/snapper_nunit.md
+++ b/docs/pages/snapper_nunit.md
@@ -20,8 +20,17 @@ public class MyTestClass
             Key = "value"
         };
         // Best to use with theory tests
-        // See https://theramis.github.io/Snapper/snapper/basics.html#child-snapshots for more information about child snapshots
+        // See https://theramis.github.io/Snapper/#/pages/snapper/basics?id=child-snapshots for more information about child snapshots
         Assert.That(obj, Is.EqualToChildSnapshot("NamedSnapshot"));
+    }
+
+    [Test]
+    public void MyThirdTest(){
+        var obj = new {
+            Key = "value"
+        };
+        // See https://theramis.github.io/Snapper/#/pages/snapper/advanced_snapshot_control for more information about `SnapshotId`
+        Assert.That(obj, Is.EqualToSnapshot(new SnapshotId("dir", "class", "method", null, false)));
     }
 }
 ```

--- a/project/Snapper.Nunit/NUnitSnapper.cs
+++ b/project/Snapper.Nunit/NUnitSnapper.cs
@@ -22,10 +22,14 @@ namespace Snapper.Nunit
 
         public SnapResult MatchChildSnapshot(object snapshot, string childSnapshotName)
         {
-            var snapId = _snapshotIdResolver.ResolveSnapshotId(childSnapshotName);
-            var sanitisedSnapshot = _snapshotSanitiser.SanitiseSnapshot(snapshot);
+            var snapshotId = _snapshotIdResolver.ResolveSnapshotId(childSnapshotName);
+            return MatchSnapshot(snapshot, snapshotId);
+        }
 
-            return Snap(snapId, sanitisedSnapshot);
+        public SnapResult MatchSnapshot(object snapshot, SnapshotId snapshotId)
+        {
+            var sanitisedSnapshot = _snapshotSanitiser.SanitiseSnapshot(snapshot);
+            return Snap(snapshotId, sanitisedSnapshot);
         }
     }
 }

--- a/project/Snapper.Nunit/SnapConstraint.cs
+++ b/project/Snapper.Nunit/SnapConstraint.cs
@@ -21,33 +21,54 @@ namespace Snapper.Nunit
             return new EqualToSnapshotConstraint();
         }
 
-        public static EqualToSnapshotConstraint EqualToChildSnapshot(string snapshotName)
+        public static EqualToSnapshotConstraint EqualToSnapshot(SnapshotId snapshotId)
         {
-            return new EqualToSnapshotConstraint(snapshotName);
+            return new EqualToSnapshotConstraint(snapshotId);
+        }
+
+        public static EqualToSnapshotConstraint EqualToChildSnapshot(string childSnapshotName)
+        {
+            return new EqualToSnapshotConstraint(childSnapshotName);
         }
     }
 
     public class EqualToSnapshotConstraint : Constraint
     {
-        private readonly string _snapshotName;
+        private readonly SnapshotId _snapshotId;
+        private readonly string _childSnapshotName;
 
-        public EqualToSnapshotConstraint(string snapshotName = null)
+        public EqualToSnapshotConstraint(string childSnapshotName = null)
         {
-            _snapshotName = snapshotName;
+            _childSnapshotName = childSnapshotName;
+        }
+
+        public EqualToSnapshotConstraint(SnapshotId snapshotId)
+        {
+            _snapshotId = snapshotId;
         }
 
         public override ConstraintResult ApplyTo<TActual>(TActual actual)
         {
-            var matchSnapshot = MatchSnapshot(actual);
-            return new NUnitConstraintResult(this, actual, matchSnapshot);
+            SnapResult snapResult;
+            if (_snapshotId != null)
+            {
+                var snapper = NUnitSnapperFactory.GetNUnitSnapper();
+                snapResult = snapper.MatchSnapshot(actual, _snapshotId);
+            }
+            else
+            {
+                snapResult = MatchSnapshot(actual);
+            }
+
+            return new NUnitConstraintResult(this, actual, snapResult);
         }
 
         private SnapResult MatchSnapshot(object actual)
         {
             var snapper = NUnitSnapperFactory.GetNUnitSnapper();
-            return _snapshotName == null
+            return _childSnapshotName == null
                    ? snapper.MatchSnapshot(actual)
-                   : snapper.MatchChildSnapshot(actual, _snapshotName);
+                   : snapper.MatchChildSnapshot(actual, _childSnapshotName);
         }
     }
 

--- a/project/Snapper/Core/Messages.cs
+++ b/project/Snapper/Core/Messages.cs
@@ -33,7 +33,7 @@ namespace Snapper.Core
         public const string TestMethodNotFoundMessage
             = "A supported test method was not found. " +
                "Make sure you are using Snapper inside a supported test framework. " +
-               "See https://theramis.github.io/Snapper/FAQS.html for more info.";
+               "See https://theramis.github.io/Snapper/#/pages/faqs for more info.";
 
         public const string MalformedJsonSnapshotMessage
             = "The snapshot provided contains malformed JSON. See inner exception for details.";

--- a/project/Snapper/Core/SnapshotId.cs
+++ b/project/Snapper/Core/SnapshotId.cs
@@ -1,18 +1,41 @@
+using System.IO;
+
 namespace Snapper.Core
 {
-    internal class SnapshotId
+    public class SnapshotId
     {
-        public string FilePath { get; }
+        internal string FilePath { get; }
 
-        public string PrimaryId { get; }
+        internal string PrimaryId { get; }
 
-        public string SecondaryId { get; }
+        internal string SecondaryId { get; }
 
-        public SnapshotId(string filePath, string primaryId = null, string secondaryId = null)
+        /// <summary>
+        ///     Describes how and where the snapshot will be stored.
+        ///     See <see href="https://theramis.github.io/Snapper/#/pages/snapper/advanced_snapshot_control">Advanced snapshot file control</see>
+        /// </summary>
+        /// <param name="snapshotDirectory">The directory where the snapshot should be stored</param>
+        /// <param name="className">The name of the class where the test is defined</param>
+        /// <param name="methodName">The name of the test method</param>
+        /// <param name="childSnapshotName">The name of the child snapshot. Use null if there none</param>
+        /// <param name="storeSnapshotsPerClass">Set to true to store snapshot per class.</param>
+        public SnapshotId(string snapshotDirectory,
+            string className,
+            string methodName,
+            string childSnapshotName = null,
+            bool storeSnapshotsPerClass = false)
         {
-            FilePath = filePath;
-            PrimaryId = primaryId;
-            SecondaryId = secondaryId;
+            if (storeSnapshotsPerClass)
+            {
+                FilePath = Path.Combine(snapshotDirectory, $"{className}.json");
+                PrimaryId = methodName;
+                SecondaryId = childSnapshotName;
+            }
+            else
+            {
+                FilePath = Path.Combine(snapshotDirectory, $"{className}{'_'}{methodName}.json");
+                PrimaryId = childSnapshotName;
+            }
         }
     }
 }

--- a/project/Snapper/Core/SnapshotIdResolver.cs
+++ b/project/Snapper/Core/SnapshotIdResolver.cs
@@ -16,7 +16,7 @@ namespace Snapper.Core
             _testMethodResolver = testMethodResolver;
         }
 
-        public SnapshotId ResolveSnapshotId(string partialSnapshotName)
+        public SnapshotId ResolveSnapshotId(string childSnapshotName)
         {
             var testMethod = _testMethodResolver.ResolveTestMethod();
             var testBaseMethod = testMethod.BaseMethod;
@@ -24,19 +24,15 @@ namespace Snapper.Core
             var directory = Path.GetDirectoryName(testMethod.FileName);
             var className = testBaseMethod.DeclaringType?.Name;
 
+            var snapshotDirectory = Path.Combine(directory, SnapshotsDirectory);
             var storeSnapshotsPerClass = ShouldStoreSnapshotsPerClass(testBaseMethod);
 
-            if (storeSnapshotsPerClass)
-            {
-                var snapshotFilePath = Path.Combine(directory, SnapshotsDirectory, $"{className}.json");
-                return new SnapshotId(snapshotFilePath, testMethod.MethodName, partialSnapshotName);
-            }
-            else
-            {
-                var snapshotFileName = $"{className}{'_'}{testMethod.MethodName}";
-                var snapshotFilePath = Path.Combine(directory, SnapshotsDirectory, $"{snapshotFileName}.json");
-                return new SnapshotId(snapshotFilePath, partialSnapshotName);
-            }
+            return new SnapshotId(
+                snapshotDirectory,
+                className,
+                testMethod.MethodName,
+                childSnapshotName,
+                storeSnapshotsPerClass);
         }
 
         private static bool ShouldStoreSnapshotsPerClass(MemberInfo method)

--- a/project/Snapper/Snapper.cs
+++ b/project/Snapper/Snapper.cs
@@ -20,15 +20,18 @@ namespace Snapper
         }
 
         public void MatchSnapshot(object snapshot)
-            => MatchSnapshot(snapshot, null);
+            => MatchSnapshot(snapshot, childSnapshotName: null);
 
-        public void MatchSnapshot(object snapshot, string partialSnapshotName)
+        public void MatchSnapshot(object snapshot, string childSnapshotName)
         {
-            var snapId = _snapshotIdResolver.ResolveSnapshotId(partialSnapshotName);
+            var snapshotId = _snapshotIdResolver.ResolveSnapshotId(childSnapshotName);
+            MatchSnapshot(snapshot, snapshotId);
+        }
+
+        public void MatchSnapshot(object snapshot, SnapshotId snapshotId)
+        {
             var sanitisedSnapshot = _snapshotSanitiser.SanitiseSnapshot(snapshot);
-
-            var result = Snap(snapId, sanitisedSnapshot);
-
+            var result = Snap(snapshotId, sanitisedSnapshot);
             _snapshotAsserter.AssertSnapshot(result);
         }
     }

--- a/project/Snapper/SnapperExtensions.cs
+++ b/project/Snapper/SnapperExtensions.cs
@@ -1,3 +1,5 @@
+using Snapper.Core;
+
 namespace Snapper
 {
     public static class SnapperExtensions
@@ -10,6 +12,23 @@ namespace Snapper
         {
             var snapper = SnapperFactory.GetJsonSnapper();
             snapper.MatchSnapshot(snapshot);
+        }
+
+        /// <summary>
+        ///     **EXPERIMENTAL**
+        ///     <para>This method may be removed or changed in future versions.</para>
+        ///     <para></para>
+        ///     <para>
+        ///     Compares the provided object with the stored snapshot.
+        ///     It takes a <c>SnapshotId</c> for finer control of how and where the snapshot is stored.
+        ///     </para>
+        /// </summary>
+        /// <param name="snapshot">The object to compare with the stored snapshot</param>
+        /// <param name="snapshotId">Describes how and where the snapshot is stored</param>
+        public static void ShouldMatchSnapshot(this object snapshot, SnapshotId snapshotId)
+        {
+            var snapper = SnapperFactory.GetJsonSnapper();
+            snapper.MatchSnapshot(snapshot, snapshotId);
         }
 
         /// <summary>

--- a/project/Tests/Snapper.Internals.Tests/Core/SnapperCoreTests.cs
+++ b/project/Tests/Snapper.Internals.Tests/Core/SnapperCoreTests.cs
@@ -46,7 +46,7 @@ namespace Snapper.Internals.Tests.Core
             _comparer.Setup(a => a.CompareSnapshots(It.IsAny<object>(), It.IsAny<object>()))
                 .Returns(true);
 
-            var result = _snapper.Snap(new SnapshotId("name"), _obj);
+            var result = _snapper.Snap(new SnapshotId("name", null, null, null), _obj);
 
             result.Status.Should().BeEquivalentTo(SnapResultStatus.SnapshotsMatch);
             result.OldSnapshot.Should().BeEquivalentTo(_obj);
@@ -61,7 +61,7 @@ namespace Snapper.Internals.Tests.Core
             _comparer.Setup(a => a.CompareSnapshots(It.IsAny<object>(), It.IsAny<object>()))
                 .Returns(true);
 
-            var result = _snapper.Snap(new SnapshotId("name"), _obj);
+            var result = _snapper.Snap(new SnapshotId("name", null, null, null), _obj);
 
             _store.Verify(a => a.StoreSnapshot(It.IsAny<SnapshotId>(), It.IsAny<object>()), Times.Never);
             result.Status.Should().BeEquivalentTo(SnapResultStatus.SnapshotsMatch);
@@ -78,7 +78,7 @@ namespace Snapper.Internals.Tests.Core
                 .Returns(false);
 
             var newObj = new {value = 2};
-            var result = _snapper.Snap(new SnapshotId("name"), newObj);
+            var result = _snapper.Snap(new SnapshotId("name", null, null, null), newObj);
 
             result.Status.Should().BeEquivalentTo(SnapResultStatus.SnapshotsDoNotMatch);
             result.OldSnapshot.Should().BeEquivalentTo(_obj);
@@ -94,7 +94,7 @@ namespace Snapper.Internals.Tests.Core
                 .Returns(false);
 
             var newObj = new {value = 2};
-            var result = _snapper.Snap(new SnapshotId("name"), newObj);
+            var result = _snapper.Snap(new SnapshotId("name", null, null, null), newObj);
 
             _store.Verify(a => a.StoreSnapshot(It.IsAny<SnapshotId>(), It.IsAny<object>()), Times.Once);
             result.Status.Should().BeEquivalentTo(SnapResultStatus.SnapshotUpdated);
@@ -108,7 +108,7 @@ namespace Snapper.Internals.Tests.Core
             _store.Setup(a => a.GetSnapshot(It.IsAny<SnapshotId>())).Returns(null);
             _updateDecider.Setup(a => a.ShouldUpdateSnapshot()).Returns(true);
 
-            var result = _snapper.Snap(new SnapshotId("name"), _obj);
+            var result = _snapper.Snap(new SnapshotId("name", null, null, null), _obj);
 
             _store.Verify(a => a.StoreSnapshot(It.IsAny<SnapshotId>(), It.IsAny<object>()), Times.Once);
             result.Status.Should().BeEquivalentTo(SnapResultStatus.SnapshotUpdated);
@@ -122,7 +122,7 @@ namespace Snapper.Internals.Tests.Core
             _store.Setup(a => a.GetSnapshot(It.IsAny<SnapshotId>())).Returns(null);
             _updateDecider.Setup(a => a.ShouldUpdateSnapshot()).Returns(false);
 
-            var result = _snapper.Snap(new SnapshotId("name"), _obj);
+            var result = _snapper.Snap(new SnapshotId("name", null, null, null), _obj);
 
             result.Status.Should().BeEquivalentTo(SnapResultStatus.SnapshotDoesNotExist);
             result.OldSnapshot.Should().BeNull();

--- a/project/Tests/Snapper.Nunit.Tests/NunitSnapperCustomTests.cs
+++ b/project/Tests/Snapper.Nunit.Tests/NunitSnapperCustomTests.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+using Snapper.Core;
+
+namespace Snapper.Nunit.Tests
+{
+    public class NunitSnapperCustomTests
+    {
+        [Test]
+        public void SnapshotsMatch()
+        {
+            // Arrange
+            var snapshot = new
+            {
+                TestValue = "value"
+            };
+
+            // Act/Assert
+            Assert.That(snapshot, Is.EqualToSnapshot(new SnapshotId(
+                Path.Combine(GetCurrentClassDirectory(), "_custom"),
+                nameof(NunitSnapperCustomTests),
+                nameof(SnapshotsMatch))));
+        }
+
+        [DatapointSource]
+        public int[] values = new int[] { 1, 2, 3 };
+
+        [Theory]
+        public void TheorySnapshotsMatch(int data)
+        {
+            // Arrange
+            var snapshot = new
+            {
+                TestValue = data
+            };
+
+            // Act/Assert
+            Assert.That(snapshot, Is.EqualToSnapshot(new SnapshotId(
+                Path.Combine(GetCurrentClassDirectory(), "_custom"),
+                nameof(NunitSnapperCustomTests),
+                nameof(TheorySnapshotsMatch),
+                data.ToString())));
+        }
+
+        [Theory]
+        public void TheorySnapshotsMatchWithPerClass(int data)
+        {
+            // Arrange
+            var snapshot = new
+            {
+                TestValue = data
+            };
+
+            // Act/Assert
+            Assert.That(snapshot, Is.EqualToSnapshot(new SnapshotId(
+                Path.Combine(GetCurrentClassDirectory(), "_custom"),
+                nameof(NunitSnapperCustomTests),
+                nameof(TheorySnapshotsMatchWithPerClass),
+                data.ToString(),
+                true)));
+        }
+
+        private static string GetCurrentClassDirectory([CallerFilePath] string callerFilePath = "")
+            => Path.GetDirectoryName(callerFilePath);
+    }
+}

--- a/project/Tests/Snapper.Nunit.Tests/_custom/NunitSnapperCustomTests.json
+++ b/project/Tests/Snapper.Nunit.Tests/_custom/NunitSnapperCustomTests.json
@@ -1,0 +1,13 @@
+{
+  "TheorySnapshotsMatchWithPerClass": {
+    "1": {
+      "TestValue": 1
+    },
+    "2": {
+      "TestValue": 2
+    },
+    "3": {
+      "TestValue": 3
+    }
+  }
+}

--- a/project/Tests/Snapper.Nunit.Tests/_custom/NunitSnapperCustomTests_SnapshotsMatch.json
+++ b/project/Tests/Snapper.Nunit.Tests/_custom/NunitSnapperCustomTests_SnapshotsMatch.json
@@ -1,0 +1,3 @@
+{
+  "TestValue": "value"
+}

--- a/project/Tests/Snapper.Nunit.Tests/_custom/NunitSnapperCustomTests_TheorySnapshotsMatch.json
+++ b/project/Tests/Snapper.Nunit.Tests/_custom/NunitSnapperCustomTests_TheorySnapshotsMatch.json
@@ -1,0 +1,11 @@
+{
+  "1": {
+    "TestValue": 1
+  },
+  "2": {
+    "TestValue": 2
+  },
+  "3": {
+    "TestValue": 3
+  }
+}

--- a/project/Tests/Snapper.Tests/SnapperCustomSnapshotIdTests.cs
+++ b/project/Tests/Snapper.Tests/SnapperCustomSnapshotIdTests.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using Snapper.Core;
+using Xunit;
+
+namespace Snapper.Tests
+{
+    public class SnapperCustomSnapshotIdTests
+    {
+        [Fact]
+        public void SnapshotsMatch()
+        {
+            // Arrange
+            var snapshot = new
+            {
+                TestValue = "value"
+            };
+
+            // Act/Assert
+            snapshot.ShouldMatchSnapshot(new SnapshotId(
+                Path.Combine(GetCurrentClassDirectory(), "_custom"),
+                nameof(SnapperCustomSnapshotIdTests),
+                nameof(SnapshotsMatch)));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void TheorySnapshotsMatch(int data)
+        {
+            // Arrange
+            var snapshot = new
+            {
+                TestValue = data
+            };
+
+            // Act/Assert
+            snapshot.ShouldMatchSnapshot(new SnapshotId(
+                Path.Combine(GetCurrentClassDirectory(), "_custom"),
+                nameof(SnapperCustomSnapshotIdTests),
+                nameof(TheorySnapshotsMatch),
+                data.ToString()));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void TheorySnapshotsMatchWithPerClass(int data)
+        {
+            // Arrange
+            var snapshot = new
+            {
+                TestValue = data
+            };
+
+            // Act/Assert
+            snapshot.ShouldMatchSnapshot(new SnapshotId(
+                Path.Combine(GetCurrentClassDirectory(), "_custom"),
+                nameof(SnapperCustomSnapshotIdTests),
+                nameof(TheorySnapshotsMatchWithPerClass),
+                data.ToString(),
+                true));
+        }
+
+        private static string GetCurrentClassDirectory([CallerFilePath] string callerFilePath = "")
+            => Path.GetDirectoryName(callerFilePath);
+    }
+}

--- a/project/Tests/Snapper.Tests/_custom/SnapperCustomSnapshotIdTests.json
+++ b/project/Tests/Snapper.Tests/_custom/SnapperCustomSnapshotIdTests.json
@@ -1,0 +1,13 @@
+{
+  "TheorySnapshotsMatchWithPerClass": {
+    "2": {
+      "TestValue": 2
+    },
+    "1": {
+      "TestValue": 1
+    },
+    "3": {
+      "TestValue": 3
+    }
+  }
+}

--- a/project/Tests/Snapper.Tests/_custom/SnapperCustomSnapshotIdTests_SnapshotsMatch.json
+++ b/project/Tests/Snapper.Tests/_custom/SnapperCustomSnapshotIdTests_SnapshotsMatch.json
@@ -1,0 +1,3 @@
+{
+  "TestValue": "value"
+}

--- a/project/Tests/Snapper.Tests/_custom/SnapperCustomSnapshotIdTests_TheorySnapshotsMatch.json
+++ b/project/Tests/Snapper.Tests/_custom/SnapperCustomSnapshotIdTests_TheorySnapshotsMatch.json
@@ -1,0 +1,11 @@
+{
+  "3": {
+    "TestValue": 3
+  },
+  "2": {
+    "TestValue": 2
+  },
+  "1": {
+    "TestValue": 1
+  }
+}


### PR DESCRIPTION
## Changes
- Introduces a new overload for `ShouldMatchSnapshot()` which takes in a `SnapshotId` object. This is used by Snapper to decide where and how the snapshot file is stored. See the docs added 
- Updates the docs to explain the new method
- Updated Snapper Nunit to have an overload with `SnapshotId` as well

## Related issues
https://github.com/theramis/Snapper/issues/48
https://github.com/theramis/Snapper/issues/30
https://github.com/theramis/Snapper/issues/24