### PR TITLE
[Issue #24] Catch exceptions while determining test method

### DIFF
--- a/docs/pages/faqs.md
+++ b/docs/pages/faqs.md
@@ -28,3 +28,11 @@ There are currently three solutions for this issue.
 ```
 
 For more information see this issue: [theramis/snapper#16](https://github.com/theramis/Snapper/issues/16)
+
+### Why am I getting a `UnableToDetermineTestFilePathException`?
+```
+Snapper.Exceptions.UnableToDetermineTestFilePathException : Unable to determine the file path of the test method. 
+Make sure optimisation of the test project is disabled. See https://theramis.github.io/Snapper/#/pages/faqs for more info.
+```
+
+This can happen when the PDB files are not generated for the test project. Try setting the `<Optimize>false</Optimize>` or `<DebugType>full</DebugType>` settings in your projects csproj file. See above for more details on how to set these.

--- a/project/Snapper/Core/Messages.cs
+++ b/project/Snapper/Core/Messages.cs
@@ -37,5 +37,10 @@ namespace Snapper.Core
 
         public const string MalformedJsonSnapshotMessage
             = "The snapshot provided contains malformed JSON. See inner exception for details.";
+
+        public const string UnableToDetermineTestFilePathMessage
+            = "Unable to determine the file path of the test method. " +
+              "Make sure optimisation of the test project is disabled. " +
+              "See https://theramis.github.io/Snapper/#/pages/faqs for more info.";
     }
 }

--- a/project/Snapper/Exceptions/SupportedTestMethodNotFoundException.cs
+++ b/project/Snapper/Exceptions/SupportedTestMethodNotFoundException.cs
@@ -9,5 +9,10 @@ namespace Snapper.Exceptions
             : base(Messages.TestMethodNotFoundMessage)
         {
         }
+
+        public SupportedTestMethodNotFoundException(Exception baseException)
+            : base(Messages.TestMethodNotFoundMessage, baseException)
+        {
+        }
     }
 }

--- a/project/Snapper/Exceptions/UnableToDetermineTestFilePathException.cs
+++ b/project/Snapper/Exceptions/UnableToDetermineTestFilePathException.cs
@@ -1,0 +1,13 @@
+using System;
+using Snapper.Core;
+
+namespace Snapper.Exceptions
+{
+    internal class UnableToDetermineTestFilePathException : Exception
+    {
+        public UnableToDetermineTestFilePathException()
+            : base(Messages.UnableToDetermineTestFilePathMessage)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Changes
Sometimes calling `stackFrame.GetFileName()` can return null when PDB files are not generated. 
Snapper now throws an exception in this case.

