### PR TITLE
Fix broken link to the quickstart page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ public void MyTest()
 }
 
 ```
-The test above is now asserting the `myUser` object with a snapshot stored on disk. Snapper helps you create this snapshot at the beginnging (see [Quick Start](docs/pages/quickstart.md)).
+The test above is now asserting the `myUser` object with a snapshot stored on disk. Snapper helps you create this snapshot at the beginnging (see [Quick Start](pages/quickstart.md)).
 
 This is the basis of snapshot testing. The idea being a baseline is first generated (in this case a json file which is our snapshot) and then everytime the test runs the output is compared to the snapshot. If the snapshot and the output from the tests don't match the test fails!
 


### PR DESCRIPTION
The current link (`(docs/pages/quickstart.md)`) 404s (see screenshot)

Trying the link from the sidebar takes me to `https://theramis.github.io/Snapper/#/pages/quickstart` in my browser (note the absence of `docs`)

![image](https://user-images.githubusercontent.com/11203599/84443064-fee75e80-ac92-11ea-9808-66c24a34f444.png)
