### PR TITLE
Merging release v2.3.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 All notable changes to the Snapper project.
 
+## [2.3.0] - 2021-01-11
+### Added
+- [Issue #69](https://github.com/theramis/Snapper/issues/69) [PR #71](https://github.com/theramis/Snapper/pull/71) Snapshots are now automatically generated on the first test run if the snapshot file does not exist.
+- [Issue #57](https://github.com/theramis/Snapper/issues/57) [PR #72](https://github.com/theramis/Snapper/pull/72) Introduced `Matches.Snapshot()` and `Matches.ChildSnapshot()` to `Snapper.Nunit` nuget package. Thanks to [@lilasquared](https://github.com/lilasquared) for the contribution.
+
+### Deprecated
+- [Issue #57](https://github.com/theramis/Snapper/issues/57) [PR #72](https://github.com/theramis/Snapper/pull/72) Deprecated `Snapper.Nunit.Is.EqualToSnapshot()` in `Snapper.Nunit`. This will be removed in Snapper V3. Thanks to [@lilasquared](https://github.com/lilasquared) for the contribution.
+
 ## [2.2.4] - 2020-03-16
 ### Added
-- [PR #60](https://github.com/theramis/Snapper/pull/60) **Experimental Feature**: Advanced snapshot file control! Get more control over how and where the snapshot file is created. See [here](https://theramis.github.io/Snapper/#/pages/snapper/advanced_snapshot_control) for more details. 
+- [PR #60](https://github.com/theramis/Snapper/pull/60) **Experimental Feature**: Advanced snapshot file control! Get more control over how and where the snapshot file is created. See [here](https://theramis.github.io/Snapper/#/pages/snapper/advanced_snapshot_control) for more details.
 Fixes the following issues: [#30](https://github.com/theramis/Snapper/issues/30) [#48](https://github.com/theramis/Snapper/issues/48) [#24](https://github.com/theramis/Snapper/issues/24).
 - [PR #58](https://github.com/theramis/Snapper/pull/58) `Snapper` can now detect the Azure DevOps CI Environment. Thanks to [@WarrenFerrell](https://github.com/WarrenFerrell) for the contribution.
 
@@ -132,6 +140,7 @@ The first stable release!
 - **Snapper.Json**: Extends Snapper.Core to provide storing snapshots in Json format
 - **Snapper.Json.Xunit**: Extends Snapper.Json and integrates with the XUnit testing framework.
 
+[2.3.0]: https://github.com/theramis/Snapper/compare/2.2.4...2.3.0
 [2.2.4]: https://github.com/theramis/Snapper/compare/2.2.3...2.2.4
 [2.2.3]: https://github.com/theramis/Snapper/compare/2.2.2...2.2.3
 [2.2.2]: https://github.com/theramis/Snapper/compare/2.2.1...2.2.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ skip_branch_with_pr: true
 max_jobs: 1
 configuration: Release
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 init:
   - git config --global core.autocrlf input
@@ -29,8 +29,6 @@ test: off
 
 test_script:
   - ps: dotnet test --no-build
-  - ps: dotnet test Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj --logger:Appveyor --no-build
-  - ps: dotnet test Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj --logger:Appveyor --no-build
 
 deploy:
   - provider: NuGet

--- a/docs/pages/quickstart.md
+++ b/docs/pages/quickstart.md
@@ -14,12 +14,13 @@ To run this quickstart, you need the following prerequisites:
 ```bash
 nuget install Snapper
 ```
-2. Create an xUnit test like shown
+1. Create an xUnit test like shown
 ```csharp
 public class MyTestClass {
 
     [Fact]
-    public void MyTest(){
+    public void MyTest()
+    {
         var obj = new {
             Key = "value"
         };
@@ -28,42 +29,26 @@ public class MyTestClass {
     }
 }
 ```
+Run the test and you'll see that it passes.
 The above code will try match the `obj` variable with a snapshot in the file `_snapshots/MyTestClass_MyTest.json` (relative to the file in which `MyTestClass` exists).
-For a new test this will fail as the file does not exist with an error similiar to this.
-```
-Snapper.Exceptions.SnapshotDoesNotExistException : A snapshot does not exist.
-Apply the [UpdateSnapshots] attribute on the test method or class and then run the test again to create a snapshot.
-```
-3. Lets create the snapshot so that the test passes. We could create the snapshot file manually if we wanted but that's a bit annoying. Luckily Snapper can generate a snapshot file for us! Apply the `[UpdateSnapshots]` attribute on the method and run the test again.
-```csharp
-public class MyTestClass {
+For a new test the snapshot file would not exist yet so Snapper automatically creates it on the first run.
+> Snapper automatically creates a new snapshot file for a new test from version v2.3.0 onwards. For previous versions use the `[UpdateSnapshots]` attribute to generate your initial snapshot.
 
-    [UpdateSnapshots]
-    [Fact]
-    public void MyTest(){
-        var obj = new {
-            Key = "value"
-        };
-
-        obj.ShouldMatchSnapshot();
-    }
-}
-```
-
-4. A file called `_snapshots/MyTestClass_MyTest.json` should have been created with the following content.
+1. A file called `_snapshots/MyTestClass_MyTest.json` should have been created with the following content.
 ```json
 {
   "Key": "value"
 }
 ```
-You can now remove the `[UpdateSnapshots]` attribute on the method. You should also commit the `_snapshots/MyTestClass_MyTest.json` snapshot file with your source code.
+You should commit the `_snapshots/MyTestClass_MyTest.json` snapshot file with your source code.
 
-5. Lets make our test fail. Update your code to the following.
+1. Lets make our test fail due to a change in requirements. Update your code to the following.
 ```csharp
 public class MyTestClass {
 
     [Fact]
-    public void MyTest(){
+    public void MyTest()
+    {
         var obj = new {
             Key = "My new value"
         };
@@ -84,6 +69,23 @@ Run the test and you will see a nice error message showing the difference betwee
     +    "Key": "My new value"
     }
 ```
-You can then update the snapshot by adding the `[UpdateSnapshots]` attribute to the test and running it again or if the change was invalid fix the failing test.
+
+1. Once you've verified the new snapshot is expected you can update the snapshot by appling the `[UpdateSnapshots]` attribute on the method and then running the test again.
+```csharp
+public class MyTestClass {
+
+    [UpdateSnapshots]
+    [Fact]
+    public void MyTest()
+    {
+        var obj = new {
+            Key = "My new value"
+        };
+
+        obj.ShouldMatchSnapshot();
+    }
+}
+```
+This will update the snapshot file with the latest snapshot. Remember to remove the `[UpdateSnapshots]` attribute before you commit your code!
 <br></br>
 For more examples of tests written using Snapper see [here](https://github.com/theramis/Snapper/tree/master/project/Tests/Snapper.Tests).

--- a/docs/pages/snapper_nunit.md
+++ b/docs/pages/snapper_nunit.md
@@ -11,7 +11,7 @@ public class MyTestClass
         var obj = new {
             Key = "value"
         };
-        Assert.That(obj, Is.EqualToSnapshot());
+        Assert.That(obj, Matches.Snapshot());
     }
 
     [Test]
@@ -21,7 +21,7 @@ public class MyTestClass
         };
         // Best to use with theory tests
         // See https://theramis.github.io/Snapper/#/pages/snapper/basics?id=child-snapshots for more information about child snapshots
-        Assert.That(obj, Is.EqualToChildSnapshot("NamedSnapshot"));
+        Assert.That(obj, Matches.ChildSnapshot("NamedSnapshot"));
     }
 
     [Test]
@@ -30,7 +30,7 @@ public class MyTestClass
             Key = "value"
         };
         // See https://theramis.github.io/Snapper/#/pages/snapper/advanced_snapshot_control for more information about `SnapshotId`
-        Assert.That(obj, Is.EqualToSnapshot(new SnapshotId("dir", "class", "method", null, false)));
+        Assert.That(obj, Matches.Snapshot(new SnapshotId("dir", "class", "method", null, false)));
     }
 }
 ```

--- a/project/Snapper.Nunit/SnapConstraint.cs
+++ b/project/Snapper.Nunit/SnapConstraint.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NUnit.Framework.Constraints;
 using Snapper.Core;
 
@@ -14,6 +14,7 @@ namespace Snapper.Nunit
         }
     }
 
+    [Obsolete("Snapper.Nunit.Is will be removed in a future release.  Please use Snapper.Nunit.Matches")]
     public class Is : NUnit.Framework.Is
     {
         public static EqualToSnapshotConstraint EqualToSnapshot()
@@ -29,6 +30,19 @@ namespace Snapper.Nunit
         public static EqualToSnapshotConstraint EqualToChildSnapshot(string childSnapshotName)
         {
             return new EqualToSnapshotConstraint(childSnapshotName);
+        }
+    }
+
+    public class Matches
+    {
+        public static EqualToSnapshotConstraint Snapshot()
+        {
+            return new EqualToSnapshotConstraint();
+        }
+
+        public static EqualToSnapshotConstraint ChildSnapshot(string snapshotName)
+        {
+            return new EqualToSnapshotConstraint(snapshotName);
         }
     }
 

--- a/project/Snapper.Nunit/SnapConstraint.cs
+++ b/project/Snapper.Nunit/SnapConstraint.cs
@@ -40,6 +40,11 @@ namespace Snapper.Nunit
             return new EqualToSnapshotConstraint();
         }
 
+        public static EqualToSnapshotConstraint Snapshot(SnapshotId snapshotId)
+        {
+            return new EqualToSnapshotConstraint(snapshotId);
+        }
+
         public static EqualToSnapshotConstraint ChildSnapshot(string snapshotName)
         {
             return new EqualToSnapshotConstraint(snapshotName);

--- a/project/Snapper.Nunit/Snapper.Nunit.csproj
+++ b/project/Snapper.Nunit/Snapper.Nunit.csproj
@@ -21,11 +21,11 @@ See Project Site for more details</Description>
 
     <ItemGroup>
       <ProjectReference Include="..\Snapper\Snapper.csproj" />
-      <PackageReference Include="MinVer" Version="2.0.0">
+      <PackageReference Include="MinVer" Version="2.4.0">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
       <PackageReference Include="NUnit" Version="3.6.0" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/project/Snapper/Attributes/UpdateSnapshotsAttribute.cs
+++ b/project/Snapper/Attributes/UpdateSnapshotsAttribute.cs
@@ -1,11 +1,11 @@
-using System;
+﻿using System;
 
 namespace Snapper.Attributes
 {
     /// <inheritdoc />
     /// <summary>
     ///     Tells Snapper to update snapshots. Can be placed on methods, classes and assembly.
-    ///     Note: Has no effect when on inline snapshots
+    ///     Note: Has no effect when using inline snapshots
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
     public class UpdateSnapshotsAttribute : Attribute

--- a/project/Snapper/Core/CIEnvironmentDetector.cs
+++ b/project/Snapper/Core/CIEnvironmentDetector.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Snapper.Core
+{
+    internal static class CiEnvironmentDetector
+    {
+        /// <summary>
+        ///     Based on https://github.com/watson/ci-info/blob/2012259979fc38517f8e3fc74daff714251b554d/index.js#L52-L59
+        /// </summary>
+        private static IEnumerable<string> CIEnvironmentVariables = new List<string>
+        {
+            "CI", // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
+            "CONTINUOUS_INTEGRATION", // Travis CI, Cirrus CI
+            "BUILD_NUMBER", // Jenkins, TeamCity
+            "BUILD_BUILDNUMBER", // Azure DevOps
+            "RUN_ID" // TaskCluster, dsari
+        };
+
+        public static bool IsCiEnv()
+        {
+            foreach (var envVarTarget in new[] { EnvironmentVariableTarget.Process, EnvironmentVariableTarget.Machine, EnvironmentVariableTarget.User })
+            {
+                var found = CIEnvironmentVariables.Any(ciEnvironmentVariable =>
+                    Environment.GetEnvironmentVariable(ciEnvironmentVariable, envVarTarget) != null);
+                if (found)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/project/Snapper/Core/Messages.cs
+++ b/project/Snapper/Core/Messages.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.Text;
-using Snapper.Attributes;
 using Snapper.Json;
 
 namespace Snapper.Core
@@ -12,12 +11,9 @@ namespace Snapper.Core
             switch (result.Status)
             {
                 case SnapResultStatus.SnapshotDoesNotExist:
-                    var attributeName = nameof(UpdateSnapshotsAttribute).Replace("Attribute", string.Empty);
                     var message = new StringBuilder();
                     message.AppendLine($"A snapshot does not exist.{Environment.NewLine}");
-                    message.AppendLine($"Apply the [{attributeName}] attribute on the " +
-                                       $"test method or class and then run the test again to " +
-                                       $"create a snapshot.");
+                    message.AppendLine("Run the test outside of a CI environment to create a snapshot.");
                     return message.ToString();
                 case SnapResultStatus.SnapshotsMatch:
                     return "Snapshots Match.";

--- a/project/Snapper/Core/SnapperCore.cs
+++ b/project/Snapper/Core/SnapperCore.cs
@@ -17,10 +17,8 @@
         protected SnapResult Snap(SnapshotId snapshotId, object newSnapshot)
         {
             var currentSnapshot = _snapshotStore.GetSnapshot(snapshotId);
-            var areSnapshotsEqual = currentSnapshot != null
-                                    && _snapshotComparer.CompareSnapshots(currentSnapshot, newSnapshot);
-
-            if (!areSnapshotsEqual && _snapshotUpdateDecider.ShouldUpdateSnapshot())
+            
+            if (ShouldUpdateSnapshot(currentSnapshot, newSnapshot))
             {
                 _snapshotStore.StoreSnapshot(snapshotId, newSnapshot);
                 return SnapResult.SnapshotUpdated(currentSnapshot, newSnapshot);
@@ -31,9 +29,27 @@
                 return SnapResult.SnapshotDoesNotExist(newSnapshot);
             }
 
-            return areSnapshotsEqual
+            return _snapshotComparer.CompareSnapshots(currentSnapshot, newSnapshot)
                 ? SnapResult.SnapshotsMatch(currentSnapshot, newSnapshot)
                 : SnapResult.SnapshotsDoNotMatch(currentSnapshot, newSnapshot);
+        }
+
+        private bool ShouldUpdateSnapshot(object currentSnapshot, object newSnapshot)
+        {
+            var snapshotsAreEqual = currentSnapshot != null
+                                    && _snapshotComparer.CompareSnapshots(currentSnapshot, newSnapshot);
+            if (!snapshotsAreEqual && _snapshotUpdateDecider.ShouldUpdateSnapshot())
+            {
+                return true;
+            }
+
+            // Create snapshot if it doesn't currently exist and its not a CI env
+            if (currentSnapshot == null)
+            {
+                return !CiEnvironmentDetector.IsCiEnv();
+            }
+
+            return false;
         }
     }
 }

--- a/project/Snapper/Core/SnapshotUpdateDecider.cs
+++ b/project/Snapper/Core/SnapshotUpdateDecider.cs
@@ -13,18 +13,6 @@ namespace Snapper.Core
         private const string UpdateSnapshotEnvironmentVariableName = "UpdateSnapshots";
         private readonly string _envVarName;
 
-        /// <summary>
-        ///     Based on https://github.com/watson/ci-info/blob/2012259979fc38517f8e3fc74daff714251b554d/index.js#L52-L59
-        /// </summary>
-        private readonly IEnumerable<string> _ciEnvironmentVariables = new List<string>
-        {
-            "CI", // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
-            "CONTINUOUS_INTEGRATION", // Travis CI, Cirrus CI
-            "BUILD_NUMBER", // Jenkins, TeamCity
-            "BUILD_BUILDNUMBER", // Azure DevOps
-            "RUN_ID" // TaskCluster, dsari
-        };
-
         public SnapshotUpdateDecider(ITestMethodResolver testMethodResolver,
             string envVarName = UpdateSnapshotEnvironmentVariableName)
         {
@@ -59,22 +47,7 @@ namespace Snapper.Core
             {
                 if (TryGetUpdateSnapshotsAttribute(customAttributeProvider, out var att))
                 {
-                    return !(att.IgnoreIfCi && IsCiEnv());
-                }
-            }
-
-            return false;
-        }
-
-        private bool IsCiEnv()
-        {
-            foreach (var envVarTarget in new[] { EnvironmentVariableTarget.Process, EnvironmentVariableTarget.Machine, EnvironmentVariableTarget.User})
-            {
-                var found = _ciEnvironmentVariables.Any(ciEnvironmentVariable =>
-                        Environment.GetEnvironmentVariable(ciEnvironmentVariable, envVarTarget) != null);
-                if (found)
-                {
-                    return true;
+                    return !(att.IgnoreIfCi && CiEnvironmentDetector.IsCiEnv());
                 }
             }
 

--- a/project/Snapper/Snapper.csproj
+++ b/project/Snapper/Snapper.csproj
@@ -20,11 +20,11 @@ See Project Site for more details</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.0.0">
+    <PackageReference Include="MinVer" Version="2.4.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/project/Tests/Snapper.Internals.Tests/Core/SnapshotUpdateDeciderTests.cs
+++ b/project/Tests/Snapper.Internals.Tests/Core/SnapshotUpdateDeciderTests.cs
@@ -33,6 +33,7 @@ namespace Snapper.Internals.Tests.Core
         {
             Environment.SetEnvironmentVariable(_envVar, value, EnvironmentVariableTarget.Process);
             _decider.ShouldUpdateSnapshot().Should().BeTrue();
+            Environment.SetEnvironmentVariable(_envVar, null, EnvironmentVariableTarget.Process);
         }
 
         [Theory]
@@ -44,6 +45,7 @@ namespace Snapper.Internals.Tests.Core
         {
             Environment.SetEnvironmentVariable(_envVar, value, EnvironmentVariableTarget.Process);
             _decider.ShouldUpdateSnapshot().Should().BeFalse();
+            Environment.SetEnvironmentVariable(_envVar, null, EnvironmentVariableTarget.Process);
         }
 
         [Theory]
@@ -54,6 +56,7 @@ namespace Snapper.Internals.Tests.Core
         {
             Environment.SetEnvironmentVariable(_envVar, value, EnvironmentVariableTarget.Process);
             _decider.ShouldUpdateSnapshot().Should().BeFalse();
+            Environment.SetEnvironmentVariable(_envVar, null, EnvironmentVariableTarget.Process);
         }
 
         [Fact]
@@ -69,6 +72,7 @@ namespace Snapper.Internals.Tests.Core
         {
             Environment.SetEnvironmentVariable(_envVar, "true", EnvironmentVariableTarget.Process);
             _decider.ShouldUpdateSnapshot().Should().BeTrue();
+            Environment.SetEnvironmentVariable(_envVar, null, EnvironmentVariableTarget.Process);
         }
 
         [Fact]
@@ -77,6 +81,7 @@ namespace Snapper.Internals.Tests.Core
         {
             Environment.SetEnvironmentVariable(_envVar, "False", EnvironmentVariableTarget.Process);
             _decider.ShouldUpdateSnapshot().Should().BeTrue();
+            Environment.SetEnvironmentVariable(_envVar, null, EnvironmentVariableTarget.Process);
         }
     }
 

--- a/project/Tests/Snapper.Internals.Tests/Snapper.Internals.Tests.csproj
+++ b/project/Tests/Snapper.Internals.Tests/Snapper.Internals.Tests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>

--- a/project/Tests/Snapper.Internals.Tests/Snapper.Internals.Tests.csproj
+++ b/project/Tests/Snapper.Internals.Tests/Snapper.Internals.Tests.csproj
@@ -6,11 +6,14 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/project/Tests/Snapper.Nunit.Tests/NUnitSnapperTests.cs
+++ b/project/Tests/Snapper.Nunit.Tests/NUnitSnapperTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -14,7 +14,7 @@ namespace Snapper.Nunit.Tests
             {
                 {"TestProperty", "TestValue"}
             };
-            Assert.That(actual, Is.EqualToSnapshot());
+            Assert.That(actual, Matches.Snapshot());
         }
 
         [Test]
@@ -25,7 +25,7 @@ namespace Snapper.Nunit.Tests
             {
                 {"TestProperty2", "TestValue2"}
             };
-            Assert.That(actual, Is.EqualToChildSnapshot("ChildSnapshot"));
+            Assert.That(actual, Matches.ChildSnapshot("ChildSnapshot"));
         }
     }
 }

--- a/project/Tests/Snapper.Nunit.Tests/NunitSnapperCustomTests.cs
+++ b/project/Tests/Snapper.Nunit.Tests/NunitSnapperCustomTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Runtime.CompilerServices;
 using NUnit.Framework;
 using Snapper.Core;
@@ -17,7 +17,7 @@ namespace Snapper.Nunit.Tests
             };
 
             // Act/Assert
-            Assert.That(snapshot, Is.EqualToSnapshot(new SnapshotId(
+            Assert.That(snapshot, Matches.Snapshot(new SnapshotId(
                 Path.Combine(GetCurrentClassDirectory(), "_custom"),
                 nameof(NunitSnapperCustomTests),
                 nameof(SnapshotsMatch))));
@@ -36,7 +36,7 @@ namespace Snapper.Nunit.Tests
             };
 
             // Act/Assert
-            Assert.That(snapshot, Is.EqualToSnapshot(new SnapshotId(
+            Assert.That(snapshot, Matches.Snapshot(new SnapshotId(
                 Path.Combine(GetCurrentClassDirectory(), "_custom"),
                 nameof(NunitSnapperCustomTests),
                 nameof(TheorySnapshotsMatch),
@@ -53,7 +53,7 @@ namespace Snapper.Nunit.Tests
             };
 
             // Act/Assert
-            Assert.That(snapshot, Is.EqualToSnapshot(new SnapshotId(
+            Assert.That(snapshot, Matches.Snapshot(new SnapshotId(
                 Path.Combine(GetCurrentClassDirectory(), "_custom"),
                 nameof(NunitSnapperCustomTests),
                 nameof(TheorySnapshotsMatchWithPerClass),

--- a/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
+++ b/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
@@ -1,13 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />

--- a/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
+++ b/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
@@ -7,9 +7,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
+++ b/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
@@ -13,7 +13,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
+++ b/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
@@ -6,13 +6,16 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/project/Tests/Snapper.Tests/Snapper.Tests.csproj
+++ b/project/Tests/Snapper.Tests/Snapper.Tests.csproj
@@ -6,9 +6,12 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/project/Tests/Snapper.Tests/Snapper.Tests.csproj
+++ b/project/Tests/Snapper.Tests/Snapper.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>

--- a/project/Tests/Snapper.Tests/SnapperSnapshotsPerClassTests.cs
+++ b/project/Tests/Snapper.Tests/SnapperSnapshotsPerClassTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Snapper.Attributes;
@@ -80,9 +80,10 @@ namespace Snapper.Tests
         }
 
         [Fact]
-        public void SnapshotDoesNotExist_SnapshotDoesNotExistException_IsThrown()
+        public void SnapshotDoesNotExist_And_IsCiEnv_SnapshotDoesNotExistException_IsThrown()
         {
             // Arrange
+            Environment.SetEnvironmentVariable("CI", "true", EnvironmentVariableTarget.Process);
             var snapshot = new
             {
                 TestValue = "value"
@@ -95,9 +96,45 @@ namespace Snapper.Tests
             Assert.NotNull(exception);
             Assert.Equal("Snapper.Exceptions.SnapshotDoesNotExistException", exception.GetType().FullName);
             Assert.Equal( $"A snapshot does not exist.{Environment.NewLine}{Environment.NewLine}" +
-                          "Apply the [UpdateSnapshots] attribute on the " +
-                          "test method or class and then run the test again to " +
-                          $"create a snapshot.{Environment.NewLine}", exception.Message);
+                          $"Run the test outside of a CI environment to create a snapshot.{Environment.NewLine}", exception.Message);
+
+            // Cleanup
+            Environment.SetEnvironmentVariable("CI", null, EnvironmentVariableTarget.Process);
+        }
+
+        [Fact]
+        public void SnapshotsDoesNotExist_SnapshotIsCreated()
+        {
+            // Arrange
+
+            // Tests run on CI so clearing the CI environment variable to emulate local machine
+            Environment.SetEnvironmentVariable("CI", null, EnvironmentVariableTarget.Process);
+
+            var snapshotFilePath = GetSnapshotFilePath<SnapperSnapshotsPerClassTests>();
+
+            var content = File.ReadAllText(snapshotFilePath);
+            var snapshotToRemove = string.Join(
+                Environment.NewLine,
+                "  \"SnapshotsDoesNotExist_SnapshotIsCreated\": {",
+                "    \"TestValue\": \"doesNotExist\"",
+                "  }");
+
+            var newContent = content.Replace(snapshotToRemove, "");
+            File.WriteAllText(snapshotFilePath, newContent);
+
+            var snapshot = new
+            {
+                TestValue = "doesNotExist"
+            };
+
+            // Act
+            snapshot.ShouldMatchSnapshot();
+
+            // Assert
+            Assert.Contains(snapshotToRemove, File.ReadAllText(snapshotFilePath));
+
+            // Cleanup
+            File.WriteAllText(snapshotFilePath, newContent);
         }
 
         [Fact]


### PR DESCRIPTION
### Changes
- Snapshots are now generated automatically on first run
- Deprecates `Snapper.Nunit.Is.EqualToSnapshot()` and introduces `Matches.Snapshot()` and `Matches.ChildSnapshot()` to `Snapper.Nunit` nuget package