### PR TITLE
Add support for TestCase and TestCaseSource attributes of NUnit

### DIFF
--- a/project/Snapper/Core/TestMethodResolver/TestMethodResolver.cs
+++ b/project/Snapper/Core/TestMethodResolver/TestMethodResolver.cs
@@ -17,6 +17,8 @@ namespace Snapper.Core.TestMethodResolver
                 new XunitFactMethod(method, fileName),
                 new XunitTheoryMethod(method, fileName),
                 new NunitTestMethod(method, fileName),
+                new NunitTestCaseMethod(method, fileName),
+                new NunitTestCaseSourceMethod(method, fileName),
                 new NunitTheoryMethod(method, fileName),
                 new MSTestTestMethod(method, fileName),
                 new MSTestDataTestMethod(method, fileName),

--- a/project/Snapper/Core/TestMethodResolver/TestMethods/NunitTestCaseMethod.cs
+++ b/project/Snapper/Core/TestMethodResolver/TestMethods/NunitTestCaseMethod.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using System.Reflection;
+
+namespace Snapper.Core.TestMethodResolver.TestMethods
+{
+    internal class NunitTestCaseMethod : BaseTestMethod, ITestMethod
+    {
+        public NunitTestCaseMethod(MemberInfo method, string fileName)
+            : base(method, fileName)
+        { }
+
+        protected override string AttributeName => "NUnit.Framework.TestCaseAttribute";
+    }
+}

--- a/project/Snapper/Core/TestMethodResolver/TestMethods/NunitTestCaseSourceMethod.cs
+++ b/project/Snapper/Core/TestMethodResolver/TestMethods/NunitTestCaseSourceMethod.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using System.Reflection;
+
+namespace Snapper.Core.TestMethodResolver.TestMethods
+{
+    internal class NunitTestCaseSourceMethod : BaseTestMethod, ITestMethod
+    {
+        public NunitTestCaseSourceMethod(MemberInfo method, string fileName)
+            : base(method, fileName)
+        { }
+
+        protected override string AttributeName => "NUnit.Framework.TestCaseSourceAttribute";
+    }
+}

--- a/project/Tests/Snapper.Nunit.Tests/NUnitSnapperTests.cs
+++ b/project/Tests/Snapper.Nunit.Tests/NUnitSnapperTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -26,6 +27,32 @@ namespace Snapper.Nunit.Tests
                 {"TestProperty2", "TestValue2"}
             };
             Assert.That(actual, Matches.ChildSnapshot("ChildSnapshot"));
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        public void TestWithCase(int a)
+        {
+            var actual = new JObject
+            {
+                {"TestProperty", a }
+            };
+            Assert.That(actual, Matches.ChildSnapshot(a.ToString()));
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public void TestWithCaseSource(string a)
+        {
+            var actual = new JObject
+            {
+                {"TestProperty", a }
+            };
+            Assert.That(actual, Matches.ChildSnapshot(a));
+        }
+
+        public static IEnumerable<TestCaseData> TestCases() {
+            yield return new TestCaseData("A");
+            yield return new TestCaseData("B");
         }
     }
 }

--- a/project/Tests/Snapper.Nunit.Tests/_snapshots/NUnitSnapperTests_TestWithCase.json
+++ b/project/Tests/Snapper.Nunit.Tests/_snapshots/NUnitSnapperTests_TestWithCase.json
@@ -1,0 +1,8 @@
+{
+  "1": {
+    "TestProperty": 1
+  },
+  "2": {
+    "TestProperty": 2
+  }
+}

--- a/project/Tests/Snapper.Nunit.Tests/_snapshots/NUnitSnapperTests_TestWithCaseSource.json
+++ b/project/Tests/Snapper.Nunit.Tests/_snapshots/NUnitSnapperTests_TestWithCaseSource.json
@@ -1,0 +1,8 @@
+{
+  "A": {
+    "TestProperty": "A"
+  },
+  "B": {
+    "TestProperty": "B"
+  }
+}


### PR DESCRIPTION
Snapper didn't recognize test methods marked with [TestCase] and [TestCaseSource].
This PR adds support for these two attributes.
It's still up to the user to use ChildSnapshots to distinguish between different executions of test method for different parameter values.