### PR TITLE
Update README.md to use correct path to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ public void MyTest()
 }
 
 ```
-The test above is now asserting the `myUser` object with a snapshot stored on disk. Snapper helps you create this snapshot at the beginnging (see [Quick Start](pages/quickstart.md)).
+The test above is now asserting the `myUser` object with a snapshot stored on disk. Snapper helps you create this snapshot at the beginnging (see [Quick Start](docs/pages/quickstart.md)).
 
 This is the basis of snapshot testing. The idea being a baseline is first generated (in this case a json file which is our snapshot) and then everytime the test runs the output is compared to the snapshot. If the snapshot and the output from the tests don't match the test fails!
 


### PR DESCRIPTION
I was looking at the documentation on GitHub and noticed the Quick Start link in the main page linked me to 404. This PR fixes that URL to open the file within the docs folder.