### PR TITLE
Use a property in custom SnapshotSettings to override whether to updating snapshot or not

### DIFF
--- a/project/Snapper/Core/SnapshotUpdateDecider.cs
+++ b/project/Snapper/Core/SnapshotUpdateDecider.cs
@@ -12,17 +12,24 @@ internal class SnapshotUpdateDecider : ISnapshotUpdateDecider
     private const string UpdateSnapshotEnvironmentVariableName = "UpdateSnapshots";
     private readonly ITestMethodResolver _testMethodResolver;
     private readonly string _envVarName;
+    private readonly SnapshotSettings? _settings;
 
     public SnapshotUpdateDecider(ITestMethodResolver testMethodResolver,
-        string envVarName = UpdateSnapshotEnvironmentVariableName)
+        string envVarName = UpdateSnapshotEnvironmentVariableName,
+        SnapshotSettings? settings = null)
     {
         _testMethodResolver = testMethodResolver;
         _envVarName = envVarName;
+        _settings = settings;
     }
 
     public bool ShouldUpdateSnapshot()
-        => ShouldUpdateSnapshotBasedOnEnvironmentVariable()
-           || ShouldUpdateSnapshotBasedOnAttribute();
+        => ShouldUpdateSnapshotBasedOnSettings() ?? 
+        (ShouldUpdateSnapshotBasedOnEnvironmentVariable() 
+        || ShouldUpdateSnapshotBasedOnAttribute());
+
+    private bool? ShouldUpdateSnapshotBasedOnSettings()
+        => _settings?.ShouldUpdateSnapshots;
 
     private bool ShouldUpdateSnapshotBasedOnEnvironmentVariable()
     {

--- a/project/Snapper/SnapperFactory.cs
+++ b/project/Snapper/SnapperFactory.cs
@@ -1,4 +1,4 @@
-using Snapper.Core;
+﻿using Snapper.Core;
 using Snapper.Core.TestMethodResolver;
 using Snapper.Json;
 
@@ -13,7 +13,7 @@ internal static class SnapperFactory
         var jsonSnapshotGenerator = new JsonSnapshotGenerator(new SnapshotIdResolver(testMethodResolver),
             new JsonSnapshotSanitiser(settings), settings);
         var snapperCore = new SnapperCore(new JsonSnapshotStore(settings),
-                new SnapshotUpdateDecider(testMethodResolver));
+                new SnapshotUpdateDecider(testMethodResolver, settings: settings));
         return new Snapper(jsonSnapshotGenerator, snapperCore);
     }
 

--- a/project/Snapper/SnapshotSettings.cs
+++ b/project/Snapper/SnapshotSettings.cs
@@ -18,6 +18,7 @@ public class SnapshotSettings
     public static Action<JsonSerializerSettings>? GlobalSnapshotSerialiserSettings;
 
     internal bool? ShouldStoreSnapshotsPerClass;
+    internal bool? ShouldUpdateSnapshots;
     internal string? Directory;
     internal string? FileName;
     internal string? ClassName;
@@ -54,6 +55,18 @@ public class SnapshotSettings
     public SnapshotSettings StoreSnapshotsPerClass(bool storeSnapshotsPerClass)
     {
         ShouldStoreSnapshotsPerClass = storeSnapshotsPerClass;
+        return this;
+    }
+
+    /// <summary>
+    /// Specifies if snapshots should be updated, taking precedence over the environment variable and 
+    /// <see cref="UpdateSnapshotsAttribute"/>.
+    /// </summary>
+    /// <param name="updateSnapshots">Whether to update snapshots or not</param>
+    /// <returns></returns>
+    public SnapshotSettings UpdateSnapshots(bool updateSnapshots)
+    {
+        ShouldUpdateSnapshots = updateSnapshots;
         return this;
     }
 

--- a/project/Tests/Snapper.Tests/Snapper.Tests.csproj
+++ b/project/Tests/Snapper.Tests/Snapper.Tests.csproj
@@ -17,4 +17,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Snapper\Snapper.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/project/Tests/Snapper.Tests/xunit.runner.json
+++ b/project/Tests/Snapper.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.github.io/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Addresses #104 allows test to run successfully when stack trace cannot be used to determine test method, by allowing the use of the "should update snapshot" env var to prevent TestMethodResolver from being invoked.