### PR TITLE
feat: support NUnit v4

### DIFF
--- a/project/Snapper.Nunit/EqualToSnapshotConstraint.cs
+++ b/project/Snapper.Nunit/EqualToSnapshotConstraint.cs
@@ -8,6 +8,8 @@ public class EqualToSnapshotConstraint : Constraint
     private readonly string? _childSnapshotName;
     private readonly SnapshotSettings? _snapshotSettings;
 
+    public override string Description { get => DisplayName; }
+
     public EqualToSnapshotConstraint(string? childSnapshotName = null, SnapshotSettings? snapshotSettings = null)
     {
         _childSnapshotName = childSnapshotName;

--- a/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
+++ b/project/Tests/Snapper.Nunit.Tests/Snapper.Nunit.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
+++ b/project/Tests/Snapper.TestFrameworkSupport.Tests/Snapper.TestFrameworkSupport.Tests.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This change should now support NUnit v3 and v4, so would be nice to backport to Snapper v2.

- closes #106
- https://github.com/nunit/nunit/blob/68d994772d10de54ac960ea8379ee966a3293083/src/NUnitFramework/framework/Constraints/Constraint.cs#L60